### PR TITLE
allow thin 1.6.x

### DIFF
--- a/skinny.gemspec
+++ b/skinny.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.8.7"
 
   s.add_dependency "eventmachine", ">= 1.0.0"
-  s.add_dependency "thin", ">= 1.5.0"
+  s.add_dependency "thin", ">= 1.5", "< 1.7"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"

--- a/skinny.gemspec
+++ b/skinny.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.8.7"
 
-  s.add_dependency "eventmachine", "~> 1.0.0"
-  s.add_dependency "thin", "~> 1.5.0"
+  s.add_dependency "eventmachine", ">= 1.0.0"
+  s.add_dependency "thin", ">= 1.5.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"


### PR DESCRIPTION
upgrading skinny from 0.2.2 to 0.2.3 cause thin to downgrade from 1.6.3

I think ~> are a very good practice for applications Gemfiles but not so for library gemspecs
specifying minimum ( and maximum if necessary is the way to go )
