### PR TITLE
Allow more recent Eventmachine and Thin gems

### DIFF
--- a/skinny.gemspec
+++ b/skinny.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.8.7"
 
-  s.add_dependency "eventmachine", "~> 1.0.0"
-  s.add_dependency "thin", ">= 1.5", "< 1.7"
+  s.add_dependency "eventmachine", "~> 1.2"
+  s.add_dependency "thin", "~> 1.5"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"


### PR DESCRIPTION
This is intended to unblock https://github.com/sj26/mailcatcher/pull/431/